### PR TITLE
Add packages option to setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,6 @@ setup(
       version='0.0.1',
       description='ASDL: Automatic Second-order Differentiation (for Fisher, Gradient covariance, Hessian, Jacobian, and Kernel) Library',
       install_requires=requirements,
-      packages=find_packages(),
+      packages=find_packages(include=['asdfghjkl', 'asdfghjkl.*']),
       python_requires='>=3.6'
       )

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup
+from setuptools import find_packages, setup
 
 with open('requirements.txt') as f:
     requirements = f.read().splitlines()
@@ -8,5 +8,6 @@ setup(
       version='0.0.1',
       description='ASDL: Automatic Second-order Differentiation (for Fisher, Gradient covariance, Hessian, Jacobian, and Kernel) Library',
       install_requires=requirements,
+      packages=find_packages(),
       python_requires='>=3.6'
       )


### PR DESCRIPTION
Add missing `packages` option to `setup.py`. Installing the library via `pip install` does not work properly without this option.