### PR TITLE
Fix an installation error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
 import setuptools
 
-if __name__ == "main":
-    setuptools.setup()
+setuptools.setup()


### PR DESCRIPTION
Hi, thank you for developing a nice tool. When I tried to install this library from the master branch, I got the following error on both Python 3.8 and 3.9.

```
> git clone https://github.com/kazukiosawa/asdfghjkl.git
> cd asdfghjkl
> pip install -e .
Obtaining file:///asdfghjkl
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
    Preparing wheel metadata ... error
    ERROR: Command errored out with exit status 1:
     command: /home/moskomule/.miniconda/envs/test/bin/python /home/moskomule/.miniconda/envs/test/lib/python3.8/site-packages/pip/_vendor/pep517/in_process/_in_process.py prepare_metadata_for_build_wheel /tmp/tmpkwhl5bh9
         cwd: /home/asdfghjkl
    Complete output (10 lines):
    Traceback (most recent call last):
      File "/home/asdfghjkl./.miniconda/envs/test/lib/python3.8/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 280, in <module>
        main()
      File "/home/asdfghjkl./.miniconda/envs/test/lib/python3.8/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 263, in main
        json_out['return_val'] = hook(**hook_input['kwargs'])
      File "/home/asdfghjkl./.miniconda/envstest/lib/python3.8/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 133, in prepare_metadata_for_build_wheel
        return hook(metadata_directory, config_settings)
      File "/tmp/pip-build-env-kvr15ak2/overlay/lib/python3.8/site-packages/setuptools/build_meta.py", line 182, in prepare_metadata_for_build_wheel
        assert len(dist_infos) == 1
    AssertionError
    ----------------------------------------
WARNING: Discarding file:///home/asdfghjkl. Command errored out with exit status 1: /home/moskomule/.miniconda/envs/test/bin/python /home/moskomule/.miniconda/envs/test/lib/python3.8/site-packages/pip/_vendor/pep517/in_process/_in_process.py prepare_metadata_for_build_wheel /tmp/tmpkwhl5bh9 Check the logs for full command output.
ERROR: Command errored out with exit status 1: /home/moskomule/.miniconda/envs/test/bin/python /home/moskomule/.miniconda/envs/test/lib/python3.8/site-packages/pip/_vendor/pep517/in_process/_in_process.py prepare_metadata_for_build_wheel /tmp/tmpkwhl5bh9 Check the logs for full command output.
```

This PR fixes this issue.