### PR TITLE
Add support for LayerNorm module

### DIFF
--- a/asdfghjkl/core.py
+++ b/asdfghjkl/core.py
@@ -6,7 +6,7 @@ from .operations import *
 from .matrices import *
 from .vector import ParamVector
 
-_supported_module_classes = (nn.Linear, nn.Conv2d, nn.BatchNorm1d, nn.BatchNorm2d, Bias, Scale)
+_supported_module_classes = (nn.Linear, nn.Conv2d, nn.BatchNorm1d, nn.BatchNorm2d, nn.LayerNorm, Bias, Scale)
 
 
 @contextmanager
@@ -218,6 +218,11 @@ def _preprocess_in_data(module, in_data, out_data):
         # restore normalized input
         in_data_norm = (out_data - layernorm.bias).div(layernorm.weight)
         in_data = in_data_norm
+        # reduce dimensions
+        norm_shape_len = len(layernorm.weight.shape)
+        in_data_shape_len = len(in_data.shape)
+        if norm_shape_len < in_data_shape_len-1:
+            in_data = in_data.sum(dim=list(range(1, in_data_shape_len-norm_shape_len)))
 
     return in_data
 
@@ -225,5 +230,11 @@ def _preprocess_in_data(module, in_data, out_data):
 def _preprocess_out_grads(module, out_grads):
     if isinstance(module, nn.Conv2d):
         out_grads = out_grads.flatten(start_dim=2)
+    
+    if isinstance(module, nn.LayerNorm):
+        norm_shape_len = len(module.weight.shape)
+        out_grads_shape_len = len(out_grads.shape)
+        if norm_shape_len < out_grads_shape_len-1:
+            out_grads = out_grads.sum(dim=list(range(1, out_grads_shape_len-norm_shape_len)))
 
     return out_grads

--- a/asdfghjkl/core.py
+++ b/asdfghjkl/core.py
@@ -219,6 +219,8 @@ def _preprocess_in_data(module, in_data, out_data):
         in_data_norm = (out_data - layernorm.bias).div(layernorm.weight)
         in_data = in_data_norm
         # reduce dimensions
+        # n x * x norm_shape[0] x norm_shape[1] x ... norm_shape[-1]
+        # -> n x norm_shape[0] x ... x norm_shape[-1]
         norm_shape_len = len(layernorm.weight.shape)
         in_data_shape_len = len(in_data.shape)
         if norm_shape_len < in_data_shape_len-1:
@@ -232,6 +234,9 @@ def _preprocess_out_grads(module, out_grads):
         out_grads = out_grads.flatten(start_dim=2)
     
     if isinstance(module, nn.LayerNorm):
+        # reduce dimensions
+        # n x * x norm_shape[0] x norm_shape[1] x ... norm_shape[-1]
+        # -> n x norm_shape[0] x ... x norm_shape[-1]
         norm_shape_len = len(module.weight.shape)
         out_grads_shape_len = len(out_grads.shape)
         if norm_shape_len < out_grads_shape_len-1:

--- a/asdfghjkl/operations/__init__.py
+++ b/asdfghjkl/operations/__init__.py
@@ -3,6 +3,7 @@ from .operation import *
 from .linear import Linear
 from .conv import Conv2d
 from .batchnorm import BatchNorm1d, BatchNorm2d
+from .layernorm import LayerNorm
 from .bias import Bias, BiasExt
 from .scale import Scale, ScaleExt
 
@@ -11,6 +12,7 @@ __all__ = [
     'Conv2d',
     'BatchNorm1d',
     'BatchNorm2d',
+    'LayerNorm',
     'Bias',
     'Scale',
     'BiasExt',
@@ -43,6 +45,8 @@ def get_op_class(module):
         return BatchNorm1d
     elif isinstance(module, nn.BatchNorm2d):
         return BatchNorm2d
+    elif isinstance(module, nn.LayerNorm):
+        return LayerNorm
     elif isinstance(module, Bias):
         return BiasExt
     elif isinstance(module, Scale):

--- a/asdfghjkl/operations/layernorm.py
+++ b/asdfghjkl/operations/layernorm.py
@@ -1,7 +1,7 @@
 import torch
 from torch import nn
 
-from .operation import Operation
+from .operation import Operation, OP_COV_KRON, OP_GRAM_HADAMARD
 
 
 class LayerNorm(Operation):

--- a/asdfghjkl/operations/layernorm.py
+++ b/asdfghjkl/operations/layernorm.py
@@ -1,0 +1,36 @@
+import torch
+from torch import nn
+
+from .operation import Operation
+
+
+class LayerNorm(Operation):
+    """
+    module.weight: normalized_shape
+    module.bias: normalized_shape
+
+    Argument shapes
+    in_data: n x normalized_shape
+    out_grads: n x normalized_shape
+
+    normalized_shape: f[0] x f[1] x ... x f[-1]
+    """
+    @staticmethod
+    def batch_grads_weight(
+        module: nn.Module, in_data: torch.Tensor, out_grads: torch.Tensor
+    ):
+        return in_data.mul(out_grads) # n x normalized_shape
+    
+    @staticmethod
+    def batch_grads_bias(module, out_grads):
+        return out_grads
+    
+    @staticmethod
+    def cov_diag_weight(module, in_data, out_grads):
+        grads = in_data.mul(out_grads)
+        return grads.mul(grads).sum(dim=0) # normalized_shape
+    
+    @staticmethod
+    def cov_diag_bias(module, out_grads):
+        return out_grads.mul(out_grads).sum(dim=0) # normalized_shape
+    

--- a/asdfghjkl/operations/layernorm.py
+++ b/asdfghjkl/operations/layernorm.py
@@ -34,3 +34,41 @@ class LayerNorm(Operation):
     def cov_diag_bias(module, out_grads):
         return out_grads.mul(out_grads).sum(dim=0) # normalized_shape
     
+    @staticmethod
+    def cov_unit_wise(module, in_data, out_grads):
+        n_features = in_data.flatten(start_dim=1).shape[1] # (f[0] x f[1] x ... x f[-1])
+        grads_w = in_data.mul(out_grads) # n x normalized_shape
+        grads_b = out_grads # n x normalized_shape
+        cov_ww = (grads_w ** 2).sum(0).flatten() # n_features x 1
+        cov_bb = (grads_b ** 2).sum(0).flatten() # n_features x 1
+        cov_wb = (grads_w * grads_b).sum(0).flatten() # n_features x 1
+        blocks = torch.zeros(n_features, 2, 2).to(in_data.device)
+        for i in range(n_features):
+            blocks[i][0][0] = cov_ww[i]
+            blocks[i][1][1] = cov_bb[i]
+            blocks[i][0][1] = blocks[i][1][0] = cov_wb[i]
+        return blocks  # n_features x 2 x 2
+
+    @staticmethod
+    def cov_kron_A(module, in_data):
+        raise ValueError(
+            f'{OP_COV_KRON} operation is not supported in LayerNorm.'
+        )
+
+    @staticmethod
+    def cov_kron_B(module, out_grads):
+        raise ValueError(
+            f'{OP_COV_KRON} operation is not supported in LayerNorm.'
+        )
+
+    @staticmethod
+    def gram_A(module, in_data1, in_data2):
+        raise ValueError(
+            f'{OP_GRAM_HADAMARD} operation is not supported in LayerNorm.'
+        )
+
+    @staticmethod
+    def gram_B(module, out_grads1, out_grads2):
+        raise ValueError(
+            f'{OP_GRAM_HADAMARD} operation is not supported in LayerNorm.'
+        )

--- a/asdfghjkl/operations/layernorm.py
+++ b/asdfghjkl/operations/layernorm.py
@@ -1,7 +1,7 @@
 import torch
 from torch import nn
 
-from .operation import Operation, OP_COV_KRON, OP_GRAM_HADAMARD
+from .operation import Operation, OP_COV_KRON, OP_COV_UNIT_WISE, OP_GRAM_HADAMARD, OP_GRAM_DIRECT
 
 
 class LayerNorm(Operation):
@@ -15,6 +15,21 @@ class LayerNorm(Operation):
 
     normalized_shape: f[0] x f[1] x ... x f[-1]
     """
+    def __init__(self, module, op_names, model_for_kernel=None):
+        if OP_COV_KRON in op_names:
+            op_names = op_names.copy()
+            # kron operation is not supported. unit_wise will be used instead.
+            op_names.remove(OP_COV_KRON)
+            op_names.append(OP_COV_UNIT_WISE)
+
+        if OP_GRAM_HADAMARD in op_names:
+            op_names = op_names.copy()
+            # gram hadamard operation is not supported. gram direct will be used instead.
+            op_names.remove(OP_GRAM_HADAMARD)
+            op_names.append(OP_GRAM_DIRECT)
+
+        super().__init__(module, op_names, model_for_kernel)
+
     @staticmethod
     def batch_grads_weight(
         module: nn.Module, in_data: torch.Tensor, out_grads: torch.Tensor

--- a/asdfghjkl/operations/operation.py
+++ b/asdfghjkl/operations/operation.py
@@ -148,7 +148,11 @@ class Operation:
             elif op_name == OP_COV_UNIT_WISE:
                 assert original_requires_grad(module, 'weight') and original_requires_grad(module, 'bias'), \
                     f'Both weight and bias have to require grad for {op_name} (module: {module}).'
-                rst = self.cov_unit_wise(module, self.extend_in_data(in_data), out_grads)
+                if not isinstance(module, (nn.BatchNorm1d, nn.BatchNorm2d, nn.BatchNorm3d, nn.LayerNorm)):
+                    in_data_extended = self.extend_in_data(in_data)
+                else:
+                    in_data_extended = in_data
+                rst = self.cov_unit_wise(module, in_data_extended, out_grads)
                 self.accumulate_result(rst, OP_COV_UNIT_WISE)
 
             elif op_name == OP_GRAM_HADAMARD:


### PR DESCRIPTION
The implementation in `operations/layernorm.py` is mostly based on `operations/batchnorm.py`.
Also, I found an error which occurred when computing unit_wise on BatchNorm due to the size mismatch between `in_data` and `out_grads`. This happened because of an unnecessary extension of `in_data` in `operations/operation.py`. I fixed this issue.
I haven't figured out how to implement kron in LayerNorm yet.