### PR TITLE
Fix module names in `module_dict` of `PreconditionedGradientMaker`

### DIFF
--- a/asdfghjkl/precondition/prec_grad_maker.py
+++ b/asdfghjkl/precondition/prec_grad_maker.py
@@ -59,7 +59,7 @@ class PreconditionedGradientMaker(GradientMaker):
                                                                   update_ratio=config.curvature_upd_ratio,
                                                                   warmup_ratio=config.curvature_warmup_ratio)
         self.state = dict(step=0)
-        self.module_dict = nn.ModuleDict({name: m for name, m in model.named_modules()
+        self.module_dict = nn.ModuleDict({name.replace('.', '_'): m for name, m in model.named_modules()
                                           if self._is_supported(name, m)})
         self.device = next(self.module_dict.parameters()).device
 

--- a/asdfghjkl/precondition/prec_grad_maker.py
+++ b/asdfghjkl/precondition/prec_grad_maker.py
@@ -59,7 +59,7 @@ class PreconditionedGradientMaker(GradientMaker):
                                                                   update_ratio=config.curvature_upd_ratio,
                                                                   warmup_ratio=config.curvature_warmup_ratio)
         self.state = dict(step=0)
-        self.module_dict = nn.ModuleDict({name.replace('.', '_'): m for name, m in model.named_modules()
+        self.module_dict = nn.ModuleDict({name.replace('.', '/'): m for name, m in model.named_modules()
                                           if self._is_supported(name, m)})
         self.device = next(self.module_dict.parameters()).device
 


### PR DESCRIPTION
Module names are [not allowed to contain "."](https://github.com/pytorch/pytorch/blob/master/torch/nn/modules/module.py#L578-L579) (although `named_modules()` returns the modules names connected with "."). I simply replaced "." with an underscore "\_". I think this should not break anything. If we would just use the last part of the module name, i.e. the string behind the last ".", the name might not be unique. Let me know if you prefer a different replacement string instead of "\_".