### PR TITLE
Skip precondition step for modules without inverse preconditioner (when `use_inv=True`)

### DIFF
--- a/asdfghjkl/precondition/natural_gradient.py
+++ b/asdfghjkl/precondition/natural_gradient.py
@@ -321,10 +321,11 @@ class NaturalGradientMaker(PreconditionedGradientMaker):
             vec_weight.data.mul_(grad_scale)
             if vec_bias is not None:
                 vec_bias.data.mul_(grad_scale)
-        kwargs = dict(vec_weight=vec_weight, vec_bias=vec_bias, use_inv=use_inv, inplace=True)
-        if shape == SHAPE_KFE:
-            kwargs['eps'] = self.config.damping
-        matrix.mvp(**kwargs)
+        if not use_inv or matrix.has_inv:
+            kwargs = dict(vec_weight=vec_weight, vec_bias=vec_bias, use_inv=use_inv, inplace=True)
+            if shape == SHAPE_KFE:
+                kwargs['eps'] = self.config.damping
+            matrix.mvp(**kwargs)
 
     def is_module_for_inv_and_precondition(self, module: nn.Module):
         if module not in self.modules_for_curvature:

--- a/asdfghjkl/symmatrix.py
+++ b/asdfghjkl/symmatrix.py
@@ -14,6 +14,7 @@ __all__ = [
     'get_n_cols_by_tril',
     'SymMatrix',
     'Kron',
+    'KFE',
     'Diag',
     'UnitWise'
 ]
@@ -404,6 +405,10 @@ class Kron:
         return self.B is not None
 
     @property
+    def has_inv(self):
+        return self.A_inv is not None and self.B_inv is not None
+
+    @property
     def A_dim(self):
         if self._A_dim is None:
             if self.A is not None:
@@ -549,6 +554,11 @@ class KFE:
     @property
     def has_scale(self):
         return self.scale is not None
+    
+    @property
+    def has_inv(self):
+        # KFE does not calculate the inverse matrix.
+        return False
 
     def update_inv(self, *args, **kwargs):
         pass
@@ -619,6 +629,10 @@ class UnitWise:
     @property
     def has_data(self):
         return self.data is not None
+
+    @property
+    def has_inv(self):
+        return self.inv is not None
 
     def mul_(self, value):
         if self.has_data:
@@ -737,6 +751,13 @@ class Diag:
     @property
     def has_bias(self):
         return self.bias is not None
+
+    @property
+    def has_inv(self):
+        has_inv = self.weight_inv is not None
+        if self.has_bias:
+            has_inv = has_inv and self.bias_inv is not None
+        return has_inv
 
     def mul_(self, value):
         if self.has_weight:

--- a/asdfghjkl/symmatrix.py
+++ b/asdfghjkl/symmatrix.py
@@ -491,15 +491,16 @@ class Kron:
 
     def update_inv(self, damping=_default_damping, calc_A_inv=True, calc_B_inv=True, eps=1e-7, replace=False):
         assert self.has_data
+        damping_A = damping_B = damping
         if self.has_A and self.has_B:
             A_eig_mean = (self.A.trace() if self.A_is_square else torch.sum(self.A ** 2)) / self.A_dim
             B_eig_mean = (self.B.trace() if self.B_is_square else torch.sum(self.B ** 2)) / self.B_dim
             pi = torch.sqrt(A_eig_mean / B_eig_mean)
-            r = damping**0.5
-            damping_A = max(r * pi, eps)
-            damping_B = max(r / pi, eps)
-        else:
-            damping_A = damping_B = damping
+            if pi != 0 and pi != float('inf'):
+                r = damping**0.5
+                damping_A = max(r * pi, eps)
+                damping_B = max(r / pi, eps)
+
 
         if calc_A_inv:
             assert self.has_A


### PR DESCRIPTION
This PR addresses the issue which arises when layers are initialized to zero; `A_inv` or `B_inv` can be `None` because `A` or `B` might be zero.

**Changes:**
- I simply chose to skip the precondition step for modules without inverse A or B, when `use_inv=True`. To implement this, I have added a `has_inv` property to the symmatrix classes. Alternatively, we could consider to add a flag which defaults to True and when set to False results in an error, like it is now. Or we could add a warning when a module is skipped.
- Moreover, I noticed an issue with the damping calculation when A or B is zero, or when the calculation of `pi` is numerically unstable. To prevent both cases, I now check that pi is not zero and not `inf`. If it is one of the two, the damping values default to `self._damping`.